### PR TITLE
Update `tape-run` to 10.0.0

### DIFF
--- a/index.esm.js
+++ b/index.esm.js
@@ -240,6 +240,7 @@ class Tonic extends window.HTMLElement {
   }
 
   _set (target, render, content = '') {
+    this.willRender && this.willRender()
     for (const node of target.querySelectorAll(Tonic._tags)) {
       if (!node.isTonicComponent) continue
 

--- a/index.js
+++ b/index.js
@@ -240,6 +240,7 @@ class Tonic extends window.HTMLElement {
   }
 
   _set (target, render, content = '') {
+    this.willRender && this.willRender()
     for (const node of target.querySelectorAll(Tonic._tags)) {
       if (!node.isTonicComponent) continue
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "benchmark": "^2.1.4",
     "esbuild": "^0.8.36",
     "standard": "14.3.1",
-    "tape-run": "^8.0.0",
+    "tape-run": "^10.0.0",
     "tapzero": "0.2.2",
     "uuid": "3.3.3"
   },


### PR DESCRIPTION
I tried to install Tonic on M1 mac, but could not install because the tape-run version was too old.
I updated tape-run to 10.0.0 and was able to install it, so I am sending you the difference as this PR.