### PR TITLE
add package.json instead of package

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -388,7 +388,7 @@ Object.assign(Tonic, {
   _reg: {},
   _stylesheetRegistry: [],
   _index: 0,
-  version: typeof require !== 'undefined' ? require('./package').version : null,
+  version: typeof require !== 'undefined' ? require('./package.json').version : null,
   SPREAD: /\.\.\.\s?(__\w+__\w+__)/g,
   ESC: /["&'<>`/]/g,
   AsyncFunctionGenerator: async function * () {}.constructor,


### PR DESCRIPTION
I noticed that this breaks when using a build process of browserify because the require statement uses `package` instead of `package.json`

This is an example repo if you want to clone and see yourself: https://github.com/nichoth/demonstration/blob/756d35b21a2b5b0a4055260ffb016633456d9e44/package.json#L6

```
% npm run build

> demonstration@0.0.0 build
> browserify -p esmify src/greeting.js > public/bundle.js && cp src/index.html public

Error: Can't walk dependency graph: Cannot find module './package' from 'node_modules/@socketsupply/tonic/index.js'
```