### PR TITLE
fix lint command not working on src/index.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /node_modules
 package-lock.json
 .source.*
-index.js
+./index.js
 dist
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "standard": {
     "ignore": [
-      "index.js",
+      "./index.js",
       "test/fixtures/*"
     ]
   },


### PR DESCRIPTION
The ignore rule defined in `package.json` and `.gitignore` caused warning about not working on `src/index.js` like the following:

```sh
> standard src/index.js

standard: Use JavaScript Standard Style (https://standardjs.com)
standard: Some warnings are present which will be errors in the next version (https://standardjs.com)
  /Users/andrewchou/GitHub/achou11/tonic/src/index.js:0:0: File ignored because of a matching ignore pattern. Use "--no-ignore" to override. (undefined) (warning)
```

Assuming that we only want to ignore `./index.js`, which is an artifact from the `build` command. Also updated the git ignore because if we omitted the rule from the standard config, it seems that Standard would adhere to the rule defined the git ignore, which (strangely) also applies to `src/index.js` and thus would cause the same warning and not work as expected