### PR TITLE
fix missing test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A component framework.",
   "scripts": {
     "lint": "standard .",
-    "test": "npm run build && npm run lint && npm run build:test | tape-run",
+    "test": "npm run build && npm run lint && esbuild --bundle test/index.js | tape-run",
     "ci:test:tape-run": "esbuild --bundle test/index.js | tape-run",
     "test:open": "npm run build && esbuild --bundle test/index.js | tape-run --browser chrome --keep-open",
     "build:base": "esbuild src/index.js --define:VERSION=\\\"$npm_package_version\\\" --outfile=index.js",


### PR DESCRIPTION
There was no script `build:test`, so the tests would not run.